### PR TITLE
Add a single passing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,28 @@ Used co-pilot
 - We were trying to implement a mock implementation of the filesystemservice, but that was very confusing for us, so we queried chatGPT to help us create a setup and tear down that went directly to the data file.
 - Copilot surprisingly did not totally understand the context of the User shape, and in retrospect we didn't give a lot of comments beside the acceptance criteria.
 
-## Media
+### Media
 
 Results of Sarah's 1st Query:
 ![line by line explanation of readAllUserDataFiles](./assets/img/readAllUserDataFiles_explanation.png)
 
 Results of Sarah's 2nd Query:
 ![what gets returned from readAllUserDataFiles](./assets/img/readAllUserDataFiles_return.png)
+
+## Testing FileSystemService with AI
+
+### Overview
+We moved forward with writing tests for FileSystemService using combination of ChatGPT and Copilot
+
+### Resources
+[out of context testing query](https://chat.openai.com/share/e1181cce-54ba-4da2-a0df-4428cd699b32)
+[contextual testing query](https://chat.openai.com/share/c783a0a8-8ff3-4c6f-a704-3c0d1da1b05d)
+
+### Notes
+- Overall process was to go between ChatGPT and Copilot. ChatGPT would write a ticket, we would copy and paste the acceptance criteria into the test file as comments, and then Copilot would write the test. The tests Copilot wrote did not work, so we queried ChatGPT further, adjusting the code with each iteration.
+- Once a working iteration for a test for write user data was written, it was very straight forward for coPilot to write passing tests for the other functions, so the rest of the methods were written and tested very rapidly (in about 10 minutes for all other tests).
+
+### Notes
 
 # Overall Thoughts on Using AI
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,22 @@ Results of Sarah's 1st Query:
 Results of Sarah's 2nd Query:
 ![what gets returned from readAllUserDataFiles](./assets/img/readAllUserDataFiles_return.png)
 
+## Writing further tests with ChatGPT
+
+### Overview
+After spending all afternoon using co-pilot and chatGPT to write the first test for fileSystemService, it went much smoother to write the rest of the tests. I was able to understand the generated code much better than the first go-around
+
+### Resources
+[Conversationg with chatGPT](https://chat.openai.com/share/fc90871e-baeb-42eb-8b42-6a9b25d32cfd)
+
+### Notes
+- Once again, generated some tickets with chatGPT and then copy and pasted the acceptance criteria into the test file as comments. 
+- Then I had co-pilot generate the rest of the tests
+
 # Overall Thoughts on Using AI
 
 - We noticed that giving chatGPT the high level assignment, it scaffolded an architecture that was a helpful jumping off point but that we ultimately strayed from. We had it write out the initial tickets and then over time realized that many of the tickets were not helpful and we did not use them. As we got further and further into the project, we started writing our own tickets and creating our own direction.
 - It it more helpful to use chatGPT for smaller, more pointed questions.
 - It was, however, helpful to have a running conversation with chatGPT where it had an understanding of the context of the project and could answer questions based on that context.
+
+

--- a/tests/fsService_tests/FileSystem.test.ts
+++ b/tests/fsService_tests/FileSystem.test.ts
@@ -1,4 +1,3 @@
-
 import { fileSystemService } from "../../Services/fileSystemService";
 import * as fs from "fs";
 const path = require("path");
@@ -7,22 +6,94 @@ describe("fileSystemService.readAllUserDataFiles", () => {
   const dataDir = path.join(__dirname, "../../data");
 
   beforeEach(async () => {
-    await fs.writeFile(path.join(dataDir, "test1.json"), JSON.stringify({ name: "test1" , age: 34, favColor: "vole", id: "snale"}), () => { });
-    await fs.writeFile(path.join(dataDir, "test2.json"), JSON.stringify({ name: "test2" , age: 34, favColor: "clear puce", id: "snake"}), () => { });
+    await fs.writeFile(
+      path.join(dataDir, "123.json"),
+      JSON.stringify({ name: "test1", age: 34, favColor: "vole", id: "123" }),
+      () => {}
+    );
+    await fs.writeFile(
+      path.join(dataDir, "456.json"),
+      JSON.stringify({
+        name: "test2",
+        age: 34,
+        favColor: "clear puce",
+        id: "456",
+      }),
+      () => {}
+    );
   });
 
   afterEach(async () => {
-    await fs.unlink(path.join(dataDir, "test1.json"), () => { });
-    await fs.unlink(path.join(dataDir, "test2.json"), () => { });
+    await fs.unlink(path.join(dataDir, "123.json"), () => {});
+    await fs.unlink(path.join(dataDir, "456.json"), () => {});
   });
 
   it("should return all users", async () => {
     const users = await fileSystemService.readAllUserDataFiles();
     expect(users).toEqual([
-      { name: "test1" , age: 34, favColor: "vole", id: "snale"},
-      { name: "test2" , age: 34, favColor: "clear puce", id: "snake"},
+      { name: "test1", age: 34, favColor: "vole", id: "123" },
+      { name: "test2", age: 34, favColor: "clear puce", id: "456" },
     ]);
   });
 });
 
+describe("fileSystemService.readUserDataFile", () => {
+  const dataDir = path.join(__dirname, "../../data");
 
+  beforeEach(async () => {
+    await fs.writeFile(
+      path.join(dataDir, "123.json"),
+      JSON.stringify({ name: "test1", age: 34, favColor: "vole", id: "123" }),
+      () => {}
+    );
+    await fs.writeFile(
+      path.join(dataDir, "456.json"),
+      JSON.stringify({
+        name: "test2",
+        age: 34,
+        favColor: "clear puce",
+        id: "456",
+      }),
+      () => {}
+    );
+  });
+
+  afterEach(async () => {
+    await fs.unlink(path.join(dataDir, "123.json"), () => {});
+    await fs.unlink(path.join(dataDir, "456.json"), () => {});
+    await fs.unlink(path.join(dataDir, "789.json"), () => {});
+  });
+
+  it("should return a user", async () => {
+    const user = await fileSystemService.readUserDataFile("123");
+    expect(user).toEqual({
+      name: "test1",
+      age: 34,
+      favColor: "vole",
+      id: "123",
+    });
+  });
+
+  it("should throw an error if the file doesn't exist", async () => {
+    try {
+      await fileSystemService.readUserDataFile("789");
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      expect(error.code).toEqual("ENOENT");
+    }
+  });
+  
+  it("should throw an error if the file is not valid JSON", async () => {
+    try {
+      await fs.writeFile(
+        path.join(dataDir, "789.json"),
+        "invalid json",
+        () => {}
+      );
+      await fileSystemService.readUserDataFile("789");
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      expect(error.code).toEqual("ENOENT");
+    }
+  });
+});

--- a/tests/fsService_tests/FileSystem.test.ts
+++ b/tests/fsService_tests/FileSystem.test.ts
@@ -1,4 +1,3 @@
-
 import { fileSystemService } from "../../Services/fileSystemService";
 import * as fs from "fs";
 const path = require("path");
@@ -7,21 +6,97 @@ describe("fileSystemService.readAllUserDataFiles", () => {
   const dataDir = path.join(__dirname, "../../data");
 
   beforeEach(async () => {
-    await fs.writeFile(path.join(dataDir, "test1.json"), JSON.stringify({ name: "test1" , age: 34, favColor: "vole", id: "snale"}), () => { });
-    await fs.writeFile(path.join(dataDir, "test2.json"), JSON.stringify({ name: "test2" , age: 34, favColor: "clear puce", id: "snake"}), () => { });
+    await fs.writeFile(
+      path.join(dataDir, "test1.json"),
+      JSON.stringify({ name: "test1", age: 34, favColor: "vole", id: "snale" }),
+      () => {}
+    );
+    await fs.writeFile(
+      path.join(dataDir, "test2.json"),
+      JSON.stringify({
+        name: "test2",
+        age: 34,
+        favColor: "clear puce",
+        id: "snake",
+      }),
+      () => {}
+    );
   });
 
   afterEach(async () => {
-    await fs.unlink(path.join(dataDir, "test1.json"), () => { });
-    await fs.unlink(path.join(dataDir, "test2.json"), () => { });
+    await fs.unlink(path.join(dataDir, "test1.json"), () => {});
+    await fs.unlink(path.join(dataDir, "test2.json"), () => {});
   });
 
   it("should return all users", async () => {
     const users = await fileSystemService.readAllUserDataFiles();
     expect(users).toEqual([
-      { name: "test1" , age: 34, favColor: "vole", id: "snale"},
-      { name: "test2" , age: 34, favColor: "clear puce", id: "snake"},
+      { name: "test1", age: 34, favColor: "vole", id: "snale" },
+      { name: "test2", age: 34, favColor: "clear puce", id: "snake" },
     ]);
+  });
+});
+
+describe("fileSystemService.writeUserDataFile", () => {
+  const dataDir = path.join(__dirname, "../../data");
+
+  afterEach(async () => {
+    await fs.unlink(path.join(dataDir, "snale.json"), () => {});
+  });
+
+  it("should write a file to the data directory", async () => {
+    const user = await fileSystemService.writeUserDataFile({
+      name: "test1",
+      age: 34,
+      favColor: "vole",
+      id: "snale",
+    });
+    expect(user).toEqual({
+      name: "test1",
+      age: 34,
+      favColor: "vole",
+      id: "snale",
+    });
+  }); 
+});
+
+describe("fileSystemService.updateUserDataFile", () => {
+  const dataDir = path.join(__dirname, "../../data");
+
+  beforeEach(async () => {
+    await fs.writeFile(
+      path.join(dataDir, "snale.json"),
+      JSON.stringify({ name: "test1", age: 34, favColor: "vole", id: "snale" }),
+      () => {}
+    );
+  });
+
+  afterEach(async () => {
+    await fs.unlink(path.join(dataDir, "snale.json"), () => {});
+  });
+
+  it("should update a file in the data directory", async () => {
+    const user = await fileSystemService.updateUserDataFile("snale", {
+      name: "test2",
+      age: 34,
+      favColor: "clear puce",
+    });
+    expect(user).toEqual({
+      name: "test2",
+      age: 34,
+      favColor: "clear puce",
+      id: "snale",
+    });
+  });
+
+  it("should throw an error if the file does not exist", async () => {
+    await expect(
+      fileSystemService.updateUserDataFile("snail", {
+        name: "test2",
+        age: 34,
+        favColor: "clear puce",
+      })
+    ).rejects.toThrow();
   });
 });
 

--- a/tests/fsService_tests/FileSystem.test.ts
+++ b/tests/fsService_tests/FileSystem.test.ts
@@ -1,0 +1,28 @@
+
+import { fileSystemService } from "../../Services/fileSystemService";
+import * as fs from "fs";
+const path = require("path");
+
+describe("fileSystemService.readAllUserDataFiles", () => {
+  const dataDir = path.join(__dirname, "../../data");
+
+  beforeEach(async () => {
+    await fs.writeFile(path.join(dataDir, "test1.json"), JSON.stringify({ name: "test1" , age: 34, favColor: "vole", id: "snale"}), () => { });
+    await fs.writeFile(path.join(dataDir, "test2.json"), JSON.stringify({ name: "test2" , age: 34, favColor: "clear puce", id: "snake"}), () => { });
+  });
+
+  afterEach(async () => {
+    await fs.unlink(path.join(dataDir, "test1.json"), () => { });
+    await fs.unlink(path.join(dataDir, "test2.json"), () => { });
+  });
+
+  it("should return all users", async () => {
+    const users = await fileSystemService.readAllUserDataFiles();
+    expect(users).toEqual([
+      { name: "test1" , age: 34, favColor: "vole", id: "snale"},
+      { name: "test2" , age: 34, favColor: "clear puce", id: "snake"},
+    ]);
+  });
+});
+
+

--- a/tests/fsService_tests/FileSystem.test.ts
+++ b/tests/fsService_tests/FileSystem.test.ts
@@ -100,4 +100,31 @@ describe("fileSystemService.updateUserDataFile", () => {
   });
 });
 
+describe("fileSystemService.deleteUserDataFile", () => {
+  const dataDir = path.join(__dirname, "../../data");
+
+  beforeEach(async () => {
+    await fs.writeFile(
+      path.join(dataDir, "snale.json"),
+      JSON.stringify({ name: "test1", age: 34, favColor: "vole", id: "snale" }),
+      () => {}
+    );
+  });
+
+  afterEach(async () => {
+    await fs.unlink(path.join(dataDir, "snale.json"), () => {});
+  });
+
+  it("should delete a file in the data directory", async () => {
+    const user = await fileSystemService.deleteUserDataFile("snale");
+    expect(user).toEqual("snale");
+  });
+
+  it("should throw an error if the file does not exist", async () => {
+    await expect(
+      fileSystemService.deleteUserDataFile("snail")
+    ).rejects.toThrow();
+  });
+});
+
 


### PR DESCRIPTION
**What this is**
Add a passing test for readAllUserDataFiles

**Context**
It took a very long time to figure out how to test the FileSystem code that co-pilot wrote but ultimately we went with a beforeEach and afterEach solution to create some test data and then tear it down after the test runs. We used chatGPT a lot to help problem solve the testing. It sent us down a rabbit hole of creating mock functions which we ultimately did not end up using. 

**Steps to verify**
run `yarn test` in terminal

**Media**
![Screenshot 2023-08-31 at 4 24 31 PM](https://github.com/olioapps/typescript-starter-lab/assets/127703007/4fb61b26-d351-4b2a-9655-ce592efe0398)
